### PR TITLE
Adjust theme typography and color chips

### DIFF
--- a/components/Theme.tsx
+++ b/components/Theme.tsx
@@ -3,10 +3,10 @@
 import { motion } from 'framer-motion'
 
 const themeColors = [
-  { name: 'Powder Blue', hex: '#BBD4E5' },
-  { name: 'Blush Pink', hex: '#F4D6DA' },
-  { name: 'Champagne', hex: '#F7E7CE' },
-  { name: 'Sage', hex: '#C9D9C3' },
+  { name: 'Powder Blue', hex: '#BFD8E9' },
+  { name: 'Blush Pink', hex: '#F6DADF' },
+  { name: 'Champagne', hex: '#F6E4C7' },
+  { name: 'Sage', hex: '#C6D6C1' },
 ]
 
 export default function ThemeSection() {
@@ -18,8 +18,8 @@ export default function ThemeSection() {
       viewport={{ once: true }}
       className="mt-12 text-center"
     >
-      <h2 className="font-playfair text-3xl text-deep-brown">Theme</h2>
-      <p className="mt-3 text-base text-mid-brown leading-relaxed">
+      <h2 className="font-playfair text-2xl text-deep-brown md:text-3xl">Theme</h2>
+      <p className="mt-3 mx-auto max-w-xs text-base leading-7 text-mid-brown">
         Our theme is soft pastels but this is not mandatory! Feel free to match the theme with your
         accessories if you like.
       </p>
@@ -27,8 +27,8 @@ export default function ThemeSection() {
         {themeColors.map((color) => (
           <div
             key={color.hex}
-            className="h-14 w-14 rounded-full border border-light-brown shadow-sm"
-            style={{ backgroundColor: color.hex, boxShadow: '0 8px 20px rgba(107, 78, 59, 0.12)' }}
+            className="h-14 w-14 rounded-full border border-light-brown shadow-[0_2px_6px_rgba(107,78,59,0.08)]"
+            style={{ backgroundColor: color.hex }}
             aria-label={`${color.name} (${color.hex})`}
           />
         ))}


### PR DESCRIPTION
## Summary
- soften the Theme section hierarchy for mobile with a smaller base heading and constrained paragraph width
- remove the heavy glow from theme color chips and add subtle tonal variation between swatches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7bbe958048324a43edd50883f7508